### PR TITLE
Automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    # virtual machine
+    runs-on: ubuntu-latest
+    # Docker container
+    container: 
+      image: "maven:3.6.3-jdk-8"
+      env:
+        MAVEN_OPTS: "-Xmx2g -XX:ReservedCodeCacheSize=1g"
+    steps:
+    # Checkout the repository at tag v* (github ref)
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        repository: stevenstetzler/axs-spark
+        path: ./axs-spark
+        ref: ${{ github.ref }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+    # Build Spark
+    - name: Build Spark
+      run: |
+        # build AxsUtilities.jar
+        cd ./axs-spark
+        ./dev/make-distribution.sh --name axs-spark --tgz -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes -DskipTests
+        mkdir -p /export
+        mv *.tgz /export/axs-spark.tgz
+    # Create the Github Release
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: "AXS Spark release ${{ github.ref }}"
+        draft: true
+        prerelease: false
+    # Add jar to release
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: /export/axs-spark.tgz
+        asset_name: axs-spark.tgz
+        asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,15 +19,9 @@ jobs:
     # Checkout the repository at tag v* (github ref)
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        repository: stevenstetzler/axs-spark
-        path: ./axs-spark
-        ref: ${{ github.ref }}
-        token: ${{ secrets.GITHUB_TOKEN }}
     # Build Spark
     - name: Build Spark
       run: |
-        # build AxsUtilities.jar
         cd ./axs-spark
         ./dev/make-distribution.sh --name axs-spark --tgz -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes -DskipTests
         mkdir -p /export

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
         - 'axs-v*' # Push events to matching axs-v*
+  create:
+    tags:
+        - 'axs-v*'
 
 name: Create Release
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+        - 'axs-v*' # Push events to matching axs-v*
 
 name: Create Release
 


### PR DESCRIPTION
Add code for automated releases. Releases triggered with tags "v*" e.g. "v1.0". 

I tried building just the SQL jar, since that's where the SMJ changes are, like you mentioned @ctslater, but I was running into build issues with Maven that I don't fully understand:

From https://spark.apache.org/docs/latest/building-spark.html#building-submodules-individually
```
$ ./build/mvn -pl :spark-sql_2.12 clean install
...
[ERROR] Failed to execute goal on project spark-sql_2.12: Could not resolve dependencies for project org.apache.spark:spark-sql_2.12:jar:3.0.0-SNAPSHOT: The following artifacts could not be resolved: org.apache.spark:spark-sketch_2.12:jar:3.0.0-SNAPSHOT, org.apache.spark:spark-core_2.12:jar:3.0.0-SNAPSHOT, org.apache.spark:spark-core_2.12:jar:tests:3.0.0-SNAPSHOT, org.apache.spark:spark-catalyst_2.12:jar:3.0.0-SNAPSHOT, org.apache.spark:spark-catalyst_2.12:jar:tests:3.0.0-SNAPSHOT, org.apache.spark:spark-tags_2.12:jar:3.0.0-SNAPSHOT, org.apache.spark:spark-tags_2.12:jar:tests:3.0.0-SNAPSHOT: Could not find artifact org.apache.spark:spark-sketch_2.12:jar:3.0.0-SNAPSHOT in apache.snapshots (https://repository.apache.org/snapshots) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```